### PR TITLE
Refreshable.only produces a simple immutable Refreshable object

### DIFF
--- a/changelog/@unreleased/pr-57.v2.yml
+++ b/changelog/@unreleased/pr-57.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Refreshable.only produces a simple immutable Refreshable object
+  links:
+  - https://github.com/palantir/refreshable/pull/57

--- a/src/main/java/com/palantir/refreshable/DefaultRefreshable.java
+++ b/src/main/java/com/palantir/refreshable/DefaultRefreshable.java
@@ -96,11 +96,6 @@ final class DefaultRefreshable<T> implements SettableRefreshable<T> {
     }
 
     @Override
-    public T get() {
-        return current;
-    }
-
-    @Override
     public synchronized Disposable subscribe(Consumer<? super T> throwingSubscriber) {
         SideEffectSubscriber<? super T> trackedSubscriber =
                 rootSubscriberTracker.newSideEffectSubscriber(throwingSubscriber, this);

--- a/src/main/java/com/palantir/refreshable/ImmutableRefreshable.java
+++ b/src/main/java/com/palantir/refreshable/ImmutableRefreshable.java
@@ -1,0 +1,65 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.refreshable;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/** An immutable implementation of {@link Refreshable} used by {@link Refreshable#only(Object)}. */
+final class ImmutableRefreshable<T> implements Refreshable<T> {
+
+    private final T value;
+
+    ImmutableRefreshable(T value) {
+        this.value = value;
+    }
+
+    @Override
+    public T current() {
+        return value;
+    }
+
+    @Override
+    public Disposable subscribe(Consumer<? super T> consumer) {
+        consumer.accept(value);
+        return ImmutableRefreshableDisposable.INSTANCE;
+    }
+
+    @Override
+    public <R> Refreshable<R> map(Function<? super T, R> function) {
+        return new ImmutableRefreshable<>(function.apply(value));
+    }
+
+    @Override
+    public String toString() {
+        return "ImmutableRefreshable{" + value + '}';
+    }
+
+    private enum ImmutableRefreshableDisposable implements Disposable {
+        INSTANCE;
+
+        @Override
+        public void dispose() {
+            // nothing to do. ImmutableRefreshable.subscribe invokes the consumer exactly once.
+        }
+
+        @Override
+        public String toString() {
+            return "ImmutableRefreshableDisposable{}";
+        }
+    }
+}

--- a/src/main/java/com/palantir/refreshable/Refreshable.java
+++ b/src/main/java/com/palantir/refreshable/Refreshable.java
@@ -31,7 +31,9 @@ public interface Refreshable<T> extends Supplier<T> {
      * @see #current
      */
     @Override
-    T get();
+    default T get() {
+        return current();
+    }
 
     /**
      * Subscribes to changes to {@code T} and invokes the given {@link Consumer} with the {@link #current} T first, and
@@ -46,7 +48,7 @@ public interface Refreshable<T> extends Supplier<T> {
     <R> Refreshable<R> map(Function<? super T, R> function);
 
     static <T> Refreshable<T> only(T only) {
-        return new DefaultRefreshable<>(only);
+        return new ImmutableRefreshable<>(only);
     }
 
     /** Creates a mutable root {@link Refreshable}, initialized with the given value. */

--- a/src/test/java/com/palantir/refreshable/ImmutableRefreshableTest.java
+++ b/src/test/java/com/palantir/refreshable/ImmutableRefreshableTest.java
@@ -1,0 +1,90 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.refreshable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class ImmutableRefreshableTest {
+
+    @ParameterizedTest
+    @EnumSource(RefreshableFactory.class)
+    void testValue(RefreshableFactory factory) {
+        Refreshable<String> refreshable = factory.of("initial");
+        assertThat(refreshable.current()).isEqualTo(refreshable.get()).isEqualTo("initial");
+    }
+
+    @ParameterizedTest
+    @EnumSource(RefreshableFactory.class)
+    void testMap(RefreshableFactory factory) {
+        Refreshable<String> refreshable = factory.of("initial").map(value -> value + value);
+        assertThat(refreshable.current()).isEqualTo(refreshable.get()).isEqualTo("initialinitial");
+    }
+
+    @ParameterizedTest
+    @EnumSource(RefreshableFactory.class)
+    void testSubscribe(RefreshableFactory factory) {
+        Refreshable<String> refreshable = factory.of("initial");
+        AtomicReference<String> subscriber = new AtomicReference<>("initial");
+        Disposable disposable = refreshable.subscribe(subscriber::set);
+        assertThat(subscriber).hasValue("initial");
+        disposable.dispose();
+    }
+
+    @ParameterizedTest
+    @EnumSource(RefreshableFactory.class)
+    void testNullValue(RefreshableFactory factory) {
+        Refreshable<String> refreshable = factory.of(null);
+        assertThat(refreshable.current()).isEqualTo(refreshable.get()).isNull();
+        AtomicReference<String> subscriber = new AtomicReference<>("initial");
+        Disposable disposable = refreshable.subscribe(subscriber::set);
+        assertThat(subscriber).hasValue(null);
+        disposable.dispose();
+
+        Refreshable<String> toNonNull = refreshable.map(_ignored -> "non-null");
+        assertThat(toNonNull.current()).isEqualTo(toNonNull.get()).isEqualTo("non-null");
+    }
+
+    @ParameterizedTest
+    @EnumSource(RefreshableFactory.class)
+    void testMapToNull(RefreshableFactory factory) {
+        Refreshable<String> refreshable = factory.of("initial");
+
+        Refreshable<String> toNull = refreshable.map(_ignored -> null);
+        assertThat(toNull.current()).isEqualTo(toNull.get()).isNull();
+    }
+
+    enum RefreshableFactory {
+        IMMUTABLE() {
+            @Override
+            <T> Refreshable<T> of(T value) {
+                return Refreshable.only(value);
+            }
+        },
+        DEFAULT() {
+            @Override
+            <T> Refreshable<T> of(T value) {
+                return Refreshable.create(value);
+            }
+        };
+
+        abstract <T> Refreshable<T> of(T value);
+    }
+}


### PR DESCRIPTION
There's no need to track references when we have prior knowledge
that values cannot change. This would have prevented an outage.

## Before this PR
reference chains.

## After this PR
==COMMIT_MSG==
Refreshable.only produces a simple immutable Refreshable object
==COMMIT_MSG==

## Possible downsides?
It's possible, though both dangerous and unlikely, that something has relied on `instanceof SettableRefreshable` or casting.
