### PR TITLE
Log warnings when refreshables have >1000 subscribers

### DIFF
--- a/changelog/@unreleased/pr-119.v2.yml
+++ b/changelog/@unreleased/pr-119.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Log warnings when refreshables have >1000 subscribers
+  links:
+  - https://github.com/palantir/refreshable/pull/119


### PR DESCRIPTION
## Before this PR
This is intended to catch resource leaks. Currently it's difficult to do without a heap dump.

## After this PR
==COMMIT_MSG==
Log warnings when refreshables have >1000 subscribers
==COMMIT_MSG==

## Possible downsides?
It's possible a refreshable may end up with 1000 legitimate subscribers? Unlikely, and we can always modify the threshold later on.
