### PR TITLE
Initial Refreshable benchmarks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,24 +40,27 @@ apply plugin: 'com.palantir.external-publish'
 apply plugin: 'com.palantir.baseline'
 apply plugin: 'com.palantir.consistent-versions'
 apply plugin: 'com.palantir.git-version'
-apply plugin: 'com.palantir.java-format'
 apply plugin: 'com.palantir.revapi'
 
-group 'com.palantir.refreshable'
-version System.env.CIRCLE_TAG ?: gitVersion()
+allprojects {
+    group 'com.palantir.refreshable'
+    version System.env.CIRCLE_TAG ?: gitVersion()
 
-repositories {
-    jcenter()
-    maven {
-        url 'https://dl.bintray.com/palantir/releases/'
+    repositories {
+        jcenter()
+        maven {
+            url 'https://dl.bintray.com/palantir/releases/'
+        }
     }
+
+    apply plugin: 'com.palantir.java-format'
+    apply plugin: 'java-library'
+    apply plugin: 'org.inferred.processors'
+
+    sourceCompatibility = 1.8
 }
 
-apply plugin: 'java-library'
-apply plugin: 'org.inferred.processors'
 apply plugin: 'com.palantir.external-publish-jar'
-
-sourceCompatibility = 1.8
 
 dependencies {
     implementation 'com.palantir.safe-logging:preconditions'

--- a/refreshable-benchmarks/build.gradle
+++ b/refreshable-benchmarks/build.gradle
@@ -1,0 +1,11 @@
+apply plugin: 'java-library'
+
+dependencies {
+    implementation rootProject
+    implementation 'org.openjdk.jmh:jmh-core'
+    annotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'
+}
+
+tasks.withType(JavaCompile) {
+    options.errorprone.enabled = false
+}

--- a/refreshable-benchmarks/src/main/java/com/palantir/refreshable/benchmarks/RefreshableBenchmark.java
+++ b/refreshable-benchmarks/src/main/java/com/palantir/refreshable/benchmarks/RefreshableBenchmark.java
@@ -1,0 +1,72 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.refreshable.benchmarks;
+
+import com.palantir.refreshable.Refreshable;
+import com.palantir.refreshable.SettableRefreshable;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 4, time = 3)
+@Measurement(iterations = 4, time = 3)
+@Threads(4)
+@Fork(value = 1)
+@SuppressWarnings("checkstyle:DesignForExtension")
+public class RefreshableBenchmark {
+
+    private final SettableRefreshable<String> refreshable = Refreshable.create("initial");
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public Refreshable<Integer> map() {
+        return refreshable.map(String::length);
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public Refreshable<Integer> slowMap() {
+        return refreshable.map(s -> {
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            return s.length();
+        });
+    }
+
+    public static void main(String[] _args) throws Exception {
+        Options opt = new OptionsBuilder()
+                .include(RefreshableBenchmark.class.getSimpleName())
+                .build();
+        new Runner(opt).run();
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,7 @@
 rootProject.name = 'refreshable'
 
+include 'refreshable-benchmarks'
+
 boolean isCiServer = System.getenv().containsKey('CI')
 buildCache {
     local {

--- a/versions.lock
+++ b/versions.lock
@@ -7,7 +7,10 @@ com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (1 c
 com.google.j2objc:j2objc-annotations:1.3 (1 constraints: b809eda0)
 com.palantir.safe-logging:preconditions:1.14.0 (1 constraints: 3805353b)
 com.palantir.safe-logging:safe-logging:1.14.0 (1 constraints: 321157d1)
+net.sf.jopt-simple:jopt-simple:4.6 (1 constraints: 610a91b7)
+org.apache.commons:commons-math3:3.2 (1 constraints: 5c0a8ab7)
 org.checkerframework:checker-qual:3.8.0 (1 constraints: 1d0a02b5)
+org.openjdk.jmh:jmh-core:1.29 (1 constraints: e004fc30)
 org.slf4j:slf4j-api:1.7.30 (1 constraints: 3d05453b)
 
 [Test dependencies]

--- a/versions.props
+++ b/versions.props
@@ -11,3 +11,4 @@ org.assertj:assertj-core = 3.19.0
 org.assertj:assertj-guava = 3.3.0
 org.mockito:* = 3.8.0
 org.jmock:jmock = 2.12.0
+org.openjdk.jmh:* = 1.29


### PR DESCRIPTION
Initial results:
```
Benchmark                     Mode  Cnt     Score       Error  Units
RefreshableBenchmark.map      avgt    4   225.953 ±  1002.288  us/op
RefreshableBenchmark.slowMap  avgt    4  5290.169 ± 62649.044  ms/op
```

==COMMIT_MSG==
Initial Refreshable benchmarks
==COMMIT_MSG==

`slowMap` operation sleeps one millisecond in addition to the baseline overhead of `map`, however we can see that it takes 5.29 seconds on average ± **62.65 seconds**. We don't recommend doing slow things in mapping functions, but this is just silly.