### PR TITLE
Allow full tree GC when a subscriber has a ref to a mapped child

### DIFF
--- a/changelog/@unreleased/pr-147.v2.yml
+++ b/changelog/@unreleased/pr-147.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Allow full tree GC when a subscriber has a ref to a mapped child
+  links:
+  - https://github.com/palantir/refreshable/pull/147


### PR DESCRIPTION
DefaultDisposable weakly references subscribers

==COMMIT_MSG==
Allow full tree GC when a subscriber has a ref to a mapped child
==COMMIT_MSG==
