### PR TITLE
Manually run the SafeLogger migration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,9 +55,9 @@ allprojects {
 apply plugin: 'com.palantir.external-publish-jar'
 
 dependencies {
+    implementation 'com.palantir.safe-logging:logger'
     implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.google.guava:guava'
-    implementation 'org.slf4j:slf4j-api'
 
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.assertj:assertj-guava'

--- a/src/main/java/com/palantir/refreshable/DefaultRefreshable.java
+++ b/src/main/java/com/palantir/refreshable/DefaultRefreshable.java
@@ -22,6 +22,8 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.lang.ref.Cleaner;
 import java.lang.ref.WeakReference;
 import java.util.Collections;
@@ -36,8 +38,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import javax.annotation.concurrent.GuardedBy;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Represents a {@code T} that may be updated over time.
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
  * undisposed side-effect subscribers keep all their ancestors alive.
  */
 final class DefaultRefreshable<T> implements SettableRefreshable<T> {
-    private static final Logger log = LoggerFactory.getLogger(DefaultRefreshable.class);
+    private static final SafeLogger log = SafeLoggerFactory.get(DefaultRefreshable.class);
     private static final Cleaner REFRESHABLE_CLEANER = Cleaner.create(new ThreadFactoryBuilder()
             .setNameFormat("DefaultRefreshable-Cleaner-%d")
             .setDaemon(true)

--- a/versions.lock
+++ b/versions.lock
@@ -1,17 +1,20 @@
 # Run ./gradlew --write-locks to regenerate this file
 com.google.code.findbugs:jsr305:3.0.2 (3 constraints: d31e2ad5)
-com.google.errorprone:error_prone_annotations:2.5.1 (2 constraints: 1d1bff59)
+com.google.errorprone:error_prone_annotations:2.5.1 (5 constraints: ac48316e)
 com.google.guava:failureaccess:1.0.1 (1 constraints: 140ae1b4)
 com.google.guava:guava:30.1.1-jre (1 constraints: a5064e53)
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (1 constraints: bd17c918)
 com.google.j2objc:j2objc-annotations:1.3 (1 constraints: b809eda0)
+com.palantir.safe-logging:logger:1.18.0 (1 constraints: 3c05413b)
+com.palantir.safe-logging:logger-slf4j:1.18.0 (1 constraints: 350e9350)
+com.palantir.safe-logging:logger-spi:1.18.0 (2 constraints: 791e0cb1)
 com.palantir.safe-logging:preconditions:1.18.0 (1 constraints: 3c05413b)
-com.palantir.safe-logging:safe-logging:1.18.0 (1 constraints: 361163d1)
+com.palantir.safe-logging:safe-logging:1.18.0 (3 constraints: 172f19fc)
 net.sf.jopt-simple:jopt-simple:4.6 (1 constraints: 610a91b7)
 org.apache.commons:commons-math3:3.2 (1 constraints: 5c0a8ab7)
 org.checkerframework:checker-qual:3.8.0 (1 constraints: 1d0a02b5)
 org.openjdk.jmh:jmh-core:1.32 (1 constraints: da04f730)
-org.slf4j:slf4j-api:1.7.32 (1 constraints: 3f05473b)
+org.slf4j:slf4j-api:1.7.32 (1 constraints: 471091b6)
 
 [Test dependencies]
 com.google.code.findbugs:annotations:3.0.1 (1 constraints: 9e0aafc3)


### PR DESCRIPTION
Automation fails due to compilation requirements to run the
build.

==COMMIT_MSG==
Manually run the SafeLogger migration
==COMMIT_MSG==