### PR TITLE
Add method to subscribe without initially invoking the consumer

### DIFF
--- a/refreshable/src/main/java/com/palantir/refreshable/DefaultRefreshable.java
+++ b/refreshable/src/main/java/com/palantir/refreshable/DefaultRefreshable.java
@@ -143,6 +143,20 @@ final class DefaultRefreshable<@DoNotLog T> implements SettableRefreshable<T> {
         }
     }
 
+    @Override
+    public Disposable subscribeLazily(Consumer<? super T> throwingSubscriber) {
+        readLock.lock();
+        try {
+            SideEffectSubscriber<? super T> trackedSubscriber =
+                    rootSubscriberTracker.newSideEffectSubscriber(throwingSubscriber, this);
+
+            Disposable disposable = subscribeToSelf(trackedSubscriber, false);
+            return new SubscribeDisposable(disposable, rootSubscriberTracker, trackedSubscriber);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
     private static final class SubscribeDisposable implements Disposable {
         private final Disposable delegate;
         private final RootSubscriberTracker rootSubscriberTracker;

--- a/refreshable/src/main/java/com/palantir/refreshable/ImmutableRefreshable.java
+++ b/refreshable/src/main/java/com/palantir/refreshable/ImmutableRefreshable.java
@@ -40,7 +40,8 @@ final class ImmutableRefreshable<T> implements Refreshable<T> {
     }
 
     @Override
-    public Disposable subscribeLazily(Consumer<? super T> consumer) {
+    public Disposable subscribeLazily(Consumer<? super T> _consumer) {
+        // the state will never change, so this is effectively a no-op
         return ImmutableRefreshableDisposable.INSTANCE;
     }
 

--- a/refreshable/src/main/java/com/palantir/refreshable/ImmutableRefreshable.java
+++ b/refreshable/src/main/java/com/palantir/refreshable/ImmutableRefreshable.java
@@ -40,6 +40,11 @@ final class ImmutableRefreshable<T> implements Refreshable<T> {
     }
 
     @Override
+    public Disposable subscribeLazily(Consumer<? super T> consumer) {
+        return ImmutableRefreshableDisposable.INSTANCE;
+    }
+
+    @Override
     public <R> Refreshable<R> map(Function<? super T, R> function) {
         return new ImmutableRefreshable<>(function.apply(value));
     }

--- a/refreshable/src/main/java/com/palantir/refreshable/Refreshable.java
+++ b/refreshable/src/main/java/com/palantir/refreshable/Refreshable.java
@@ -42,6 +42,12 @@ public interface Refreshable<T> extends Supplier<T> {
     Disposable subscribe(Consumer<? super T> consumer);
 
     /**
+     * Subscribes to changes to {@code T} without invoking the consumer immediately.
+     * The consumer will only be invoked when future changes occur.
+     */
+    Disposable subscribeLazily(Consumer<? super T> consumer);
+
+    /**
      * Returns a new {@link Refreshable} that handles updates to the {@code R} derived by applying the given
      * {@link Function} to the {@code T} managed by the current {@link Refreshable}.
      */

--- a/refreshable/src/test/java/com/palantir/refreshable/RefreshableTest.java
+++ b/refreshable/src/test/java/com/palantir/refreshable/RefreshableTest.java
@@ -167,6 +167,19 @@ public final class RefreshableTest {
     }
 
     @Test
+    public void testSubscribeLazily_doesNotCallImmediately() {
+        SettableRefreshable<Integer> ref = Refreshable.create(1);
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        ref.subscribeLazily(value -> callCount.incrementAndGet());
+
+        assertThat(callCount.get()).isZero();
+
+        ref.update(2);
+        assertThat(callCount.get()).isOne();
+    }
+
+    @Test
     public void testRefreshable_doesNotBreakOnException() throws Exception {
         IllegalArgumentException exception = new IllegalArgumentException();
         when(producer.call()).thenThrow(exception).thenReturn(UPDATED_CONFIG);


### PR DESCRIPTION
`Refreshable::subscribe` calls the consumer with the initial value immediately, but this is not always desirable behavior. A simple example would be during server initialization, where you may want to set up a subscriber before everything used in the consumer has been initialized. 

There are obviously ways to skip the first invocation manually, e.g. checking a flag every time or setting the initial value to an "empty" one if applicable, but building this into the library directly is cleaner. Exposing a `subscribeLazily` method also makes the behavior of `subscribe` more clear, since the term "subscribe" does not directly imply that the consumer is immediately invoked.